### PR TITLE
gcc requires all params have names

### DIFF
--- a/src/channel.c
+++ b/src/channel.c
@@ -91,7 +91,7 @@ void channel_refcount_dec(channel_t* channel) {
 	}
 }
 
-static int channel_magic_destroy(pTHX_ SV*, MAGIC* magic) {
+static int channel_magic_destroy(pTHX_ SV* sv, MAGIC* magic) {
 	channel_refcount_dec((channel_t*)magic->mg_ptr);
 	return 0;
 }

--- a/src/promise.c
+++ b/src/promise.c
@@ -113,7 +113,7 @@ void promise_refcount_dec(promise_t* promise) {
 	}
 }
 
-static int promise_destroy(pTHX_ SV*, MAGIC* magic) {
+static int promise_destroy(pTHX_ SV* sv, MAGIC* magic) {
 	promise_t* promise = (promise_t*)magic->mg_ptr;
 	promise_abandon(promise);
 	promise_refcount_dec(promise);


### PR DESCRIPTION
Avoids compiletime error:

```
src/channel.c: In function ‘channel_magic_destroy’:
src/channel.c:94:40: error: parameter name omitted
   94 | static int channel_magic_destroy(pTHX_ SV*, MAGIC* magic) {
      |                                        ^~~
```