### PR TITLE
set the size of mthread buffer correctly

### DIFF
--- a/src/mthread.c
+++ b/src/mthread.c
@@ -140,7 +140,7 @@ Promise* S_thread_spawn(pTHX_ AV* to_run) {
 	av_unshift(to_run, 1);
 	av_store(to_run, 0, (SV*)clone_INC());
 
-	mthread* mthread = calloc(1, sizeof(mthread));
+	mthread* mthread = calloc(1, sizeof(*mthread));
 	Promise* input = promise_alloc(2);
 	mthread->input = input;
 	Promise* output = promise_alloc(2);


### PR DESCRIPTION
"mthread" the type is shadowed by "mthread" the variable. Because of
that, the allocated buffer was too small, which was causing crashes on
Windows.

PS. It seems that "master" is the main branch, but "dev" is set as the default. You might want to change this.
PS2. Is the use of hard tabs in the code intentional?