### PR TITLE
thread callback must return DWORD on Windows

### DIFF
--- a/src/mthread.c
+++ b/src/mthread.c
@@ -61,7 +61,13 @@ typedef struct mthread {
 	Promise* output;
 } mthread;
 
-static void* run_thread(void* arg) {
+
+#ifdef _WIN32
+static DWORD WINAPI
+#else
+static void*
+#endif
+run_thread(void* arg) {
 	static const char* argv[] = { "perl", "-e", "0", NULL };
 	static const int argc = sizeof argv / sizeof *argv - 1;
 


### PR DESCRIPTION
Also, its calling convention must be WINAPI. It's very important for
32-bit builds because the default calling convention is different. On
64 bits it's a no-op.